### PR TITLE
Fix UV raycast intersection

### DIFF
--- a/Assets/Black Orbit/Scripts/Core/helper/UVHitDetectorGPU.cs
+++ b/Assets/Black Orbit/Scripts/Core/helper/UVHitDetectorGPU.cs
@@ -69,13 +69,13 @@ namespace Black_Orbit.Scripts.Core.Helper
             { Cache[mesh] = c = new MeshCache(mesh); }                           // :contentReference[oaicite:8]{index=8}
 
             // --- буферы результата ------------------------------------------
-            _bestDist ??= new ComputeBuffer(1, sizeof(uint),  ComputeBufferType.Raw);
+            _bestDist ??= new ComputeBuffer(1, sizeof(uint),  ComputeBufferType.Structured);
             _bestUV   ??= new ComputeBuffer(1, sizeof(float)*2);
             _bestDist.SetData(DistInit);
             _bestUV  .SetData(UvInit);
 
             // --- параметры луча в локальных координатах ---------------------
-            float3 ro = tr.InverseTransformPoint(hit.point);
+            float3 ro = tr.InverseTransformPoint(hit.point + hit.normal * 0.01f);
             float3 rd = tr.InverseTransformDirection(-hit.normal).normalized;
 
             // --- заполняем шейдер -------------------------------------------


### PR DESCRIPTION
## Summary
- correct UV hit point detection by offsetting the ray origin before dispatching the GPU compute shader
- ensure the compute shader uses a structured buffer for distance tracking

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687cfe154628832aa72775600836ba45