### PR TITLE
Allow retreat decision to use profile health thresholds

### DIFF
--- a/Assets/Black Orbit/Scripts/AI/Runtime/Actions/Tactics/RetreatDecisionAction.cs
+++ b/Assets/Black Orbit/Scripts/AI/Runtime/Actions/Tactics/RetreatDecisionAction.cs
@@ -15,20 +15,24 @@ namespace Black_Orbit.Scripts.AI.Runtime.Actions.Tactics
         private readonly float _retreatDistance;
         private readonly bool _preferCover;
         private readonly UtilityCurveSet _curves;
+        private readonly float _criticalHealth;
+        private readonly float _maxHealth;
 
-        public RetreatDecisionAction(Transform agent, UtilityCurveSet curves, float baseWeight, float retreatDistance, bool preferCover)
+        public RetreatDecisionAction(Transform agent, UtilityCurveSet curves, float baseWeight, float retreatDistance, bool preferCover, float criticalHealth, float maxHealth)
             : base(DomainId.Tactics, ExecutionType.Overlay, baseWeight)
         {
             _agent = agent;
             _retreatDistance = Mathf.Max(1f, retreatDistance);
             _preferCover = preferCover;
             _curves = curves ?? throw new ArgumentNullException(nameof(curves));
+            _criticalHealth = Mathf.Clamp01(criticalHealth);
+            _maxHealth = Mathf.Clamp01(maxHealth);
         }
 
         public override IEnumerable<IConsideration> GetConsiderations()
         {
             // Основной драйвер — LowHealth
-            yield return new LowHealth(_curves);
+            yield return new LowHealth(_curves, _criticalHealth, _maxHealth);
         }
 
         protected override void OnStart(Blackboard.Blackboard bb)

--- a/Assets/Black Orbit/Scripts/AI/Runtime/Controller/AIProfileLoader.cs
+++ b/Assets/Black Orbit/Scripts/AI/Runtime/Controller/AIProfileLoader.cs
@@ -181,7 +181,9 @@ namespace Black_Orbit.Scripts.AI.Runtime.Controller
                     domain.AddAction(new RetreatDecisionAction(transform, ctrl.UtilityCurves,
                         profile.Tactics.RetreatDecision.baseWeight,
                         profile.Tactics.RetreatDecision.retreatDistance,
-                        profile.Tactics.RetreatDecision.preferCover));
+                        profile.Tactics.RetreatDecision.preferCover,
+                        profile.Tactics.RetreatDecision.critical,
+                        profile.Tactics.RetreatDecision.max));
                 }
 
                 // RetreatMove регистрируется в Movement домене, т.к. это движение


### PR DESCRIPTION
## Summary
- pass profile-configured critical and max health thresholds into RetreatDecisionAction
- propagate those thresholds to the LowHealth consideration when deciding to retreat

## Testing
- not run (requires Unity play mode)

------
https://chatgpt.com/codex/tasks/task_e_68f16a6f6470832aa08de99452375951