### PR TITLE
Cache AI action considerations to reduce allocations

### DIFF
--- a/Assets/Black Orbit/Scripts/AI/Runtime/Actions/AIAction.cs
+++ b/Assets/Black Orbit/Scripts/AI/Runtime/Actions/AIAction.cs
@@ -18,6 +18,8 @@ namespace Black_Orbit.Scripts.AI.Runtime.Actions
         protected readonly DomainId domainId;
         protected readonly ExecutionType executionType;
         protected readonly float baseWeight;
+        private readonly List<IConsideration> _considerations = new();
+        private readonly List<float> _considerationValues = new();
 
         protected AIAction(DomainId domain, ExecutionType exec, float baseWeight = 1f)
         {
@@ -26,14 +28,44 @@ namespace Black_Orbit.Scripts.AI.Runtime.Actions
             this.baseWeight = baseWeight;
         }
 
-        public virtual IEnumerable<IConsideration> GetConsiderations() { yield break; }
+        protected IReadOnlyList<IConsideration> CachedConsiderations => _considerations;
+
+        public virtual IEnumerable<IConsideration> GetConsiderations() => _considerations;
+
+        protected void AddConsideration(IConsideration consideration)
+        {
+            if (consideration == null) return;
+            _considerations.Add(consideration);
+            if (_considerationValues.Capacity < _considerations.Count)
+                _considerationValues.Capacity = _considerations.Count;
+        }
+
+        protected void AddConsiderations(params IConsideration[] considerations)
+        {
+            if (considerations == null) return;
+            for (int i = 0; i < considerations.Length; i++)
+            {
+                AddConsideration(considerations[i]);
+            }
+        }
+
+        protected void ClearConsiderations()
+        {
+            _considerations.Clear();
+            _considerationValues.Clear();
+        }
 
         public virtual float ComputeUtility(Blackboard.Blackboard bb)
         {
-            var vals = new List<float>();
-            foreach (var c in GetConsiderations())
-                vals.Add(Mathf.Clamp01(c.Evaluate(bb)));
-            float combined = UtilityEvaluator.CombineMultiplyCompensate(vals);
+            _considerationValues.Clear();
+            for (int i = 0; i < _considerations.Count; i++)
+            {
+                var consideration = _considerations[i];
+                if (consideration == null) continue;
+                _considerationValues.Add(Mathf.Clamp01(consideration.Evaluate(bb)));
+            }
+
+            float combined = UtilityEvaluator.CombineMultiplyCompensate(_considerationValues);
             return Mathf.Clamp01(combined * Mathf.Max(0f, BaseWeight));
         }
 

--- a/Assets/Black Orbit/Scripts/AI/Runtime/Actions/Combat/ReloadAction.cs
+++ b/Assets/Black Orbit/Scripts/AI/Runtime/Actions/Combat/ReloadAction.cs
@@ -23,11 +23,7 @@ namespace Black_Orbit.Scripts.AI.Runtime.Actions.Combat
             _lowThreshold = Mathf.Max(0, lowThreshold);
             _highThreshold = Mathf.Max(_lowThreshold + 1, highThreshold);
             _curves = curves ?? throw new ArgumentNullException(nameof(curves));
-        }
-
-        public override System.Collections.Generic.IEnumerable<IConsideration> GetConsiderations()
-        {
-            yield return new AmmoLow(_curves, _lowThreshold, _highThreshold);
+            AddConsideration(new AmmoLow(_curves, _lowThreshold, _highThreshold));
         }
 
         public override bool CanStart(Blackboard.Blackboard bb)

--- a/Assets/Black Orbit/Scripts/AI/Runtime/Actions/Combat/ShootAction.cs
+++ b/Assets/Black Orbit/Scripts/AI/Runtime/Actions/Combat/ShootAction.cs
@@ -24,12 +24,9 @@ namespace Black_Orbit.Scripts.AI.Runtime.Actions.Combat
             _retreatPenalty = Mathf.Clamp01(retreatPenalty);
             _suppressBoost = Mathf.Max(0.1f, suppressBoost);
             _curves = curves ?? throw new ArgumentNullException(nameof(curves));
-        }
-
-        public override System.Collections.Generic.IEnumerable<IConsideration> GetConsiderations()
-        {
-            yield return new HasAmmo(_curves);
-            yield return new Visibility(_curves);
+            AddConsiderations(
+                new HasAmmo(_curves),
+                new Visibility(_curves));
         }
 
         public override bool CanStart(Blackboard.Blackboard bb)

--- a/Assets/Black Orbit/Scripts/AI/Runtime/Actions/Combat/ThrowGrenadeAction.cs
+++ b/Assets/Black Orbit/Scripts/AI/Runtime/Actions/Combat/ThrowGrenadeAction.cs
@@ -34,13 +34,9 @@ namespace Black_Orbit.Scripts.AI.Runtime.Actions.Combat
             _maxRange = Mathf.Max(_minRange + 0.1f, maxRange);
             _cooldown = Mathf.Max(0.1f, cooldown);
             _curves = curves ?? throw new ArgumentNullException(nameof(curves));
-        }
-
-        public override System.Collections.Generic.IEnumerable<IConsideration> GetConsiderations()
-        {
-            // Видимость цели и нахождение цели в диапазоне броска
-            yield return new Visibility(_curves);
-            yield return new GrenadeRange(_curves, _agent, _minRange, _maxRange);
+            AddConsiderations(
+                new Visibility(_curves),
+                new GrenadeRange(_curves, _agent, _minRange, _maxRange));
         }
 
         public override bool CanStart(Blackboard.Blackboard bb)

--- a/Assets/Black Orbit/Scripts/AI/Runtime/Actions/Movement/ExploreAreaAction.cs
+++ b/Assets/Black Orbit/Scripts/AI/Runtime/Actions/Movement/ExploreAreaAction.cs
@@ -23,11 +23,7 @@ namespace Black_Orbit.Scripts.AI.Runtime.Actions.Movement
             _motor = motor;
             _radius = Mathf.Max(5f, radius);
             _curves = curves ?? throw new ArgumentNullException(nameof(curves));
-        }
-
-        public override System.Collections.Generic.IEnumerable<IConsideration> GetConsiderations()
-        {
-            yield return new ExploreNeed(_curves);
+            AddConsideration(new ExploreNeed(_curves));
         }
 
         public override bool CanStart(Blackboard.Blackboard bb)

--- a/Assets/Black Orbit/Scripts/AI/Runtime/Actions/Movement/FlankEnemyAction.cs
+++ b/Assets/Black Orbit/Scripts/AI/Runtime/Actions/Movement/FlankEnemyAction.cs
@@ -25,13 +25,9 @@ namespace Black_Orbit.Scripts.AI.Runtime.Actions.Movement
             _flankDistance = Mathf.Max(3f, flankDistance);
             _orderBoost = Mathf.Max(0.1f, orderBoost);
             _curves = curves ?? throw new ArgumentNullException(nameof(curves));
-        }
-
-        public override System.Collections.Generic.IEnumerable<IConsideration> GetConsiderations()
-        {
-            // Лучше фланговать когда цель видна и мы не слишком близко
-            yield return new Visibility(_curves);
-            yield return new DistanceToTarget(_curves, _agent, _flankDistance * 3f, invert: false);
+            AddConsiderations(
+                new Visibility(_curves),
+                new DistanceToTarget(_curves, _agent, _flankDistance * 3f, invert: false));
         }
 
         public override bool CanStart(Blackboard.Blackboard bb) => _motor != null;

--- a/Assets/Black Orbit/Scripts/AI/Runtime/Actions/Movement/PursueTargetAction.cs
+++ b/Assets/Black Orbit/Scripts/AI/Runtime/Actions/Movement/PursueTargetAction.cs
@@ -22,13 +22,9 @@ namespace Black_Orbit.Scripts.AI.Runtime.Actions.Movement
             _motor = motor;
             _maxDistance = Mathf.Max(5f, maxDistance);
             _curves = curves ?? throw new ArgumentNullException(nameof(curves));
-        }
-
-        public override System.Collections.Generic.IEnumerable<IConsideration> GetConsiderations()
-        {
-            // Чем дальше цель и чем лучше видимость — тем выше приоритет преследования
-            yield return new DistanceToTarget(_curves, _agent, _maxDistance, invert: false);
-            yield return new Visibility(_curves);
+            AddConsiderations(
+                new DistanceToTarget(_curves, _agent, _maxDistance, invert: false),
+                new Visibility(_curves));
         }
 
         public override bool CanStart(Blackboard.Blackboard bb)

--- a/Assets/Black Orbit/Scripts/AI/Runtime/Actions/Movement/RetreatMoveAction.cs
+++ b/Assets/Black Orbit/Scripts/AI/Runtime/Actions/Movement/RetreatMoveAction.cs
@@ -16,12 +16,7 @@ namespace Black_Orbit.Scripts.AI.Runtime.Actions.Movement
             : base(DomainId.Movement, ExecutionType.Parallel, baseWeight)
         {
             _motor = motor; _agent = agent;
-        }
-
-        public override System.Collections.Generic.IEnumerable<IConsideration> GetConsiderations()
-        {
-            yield return new IsRetreating();
-            // Можно добавить инверсию Visibility, чтобы усилить при видимой угрозе
+            AddConsideration(new IsRetreating());
         }
 
         public override bool CanStart(Blackboard.Blackboard bb) => _motor != null;

--- a/Assets/Black Orbit/Scripts/AI/Runtime/Actions/Movement/TakeCoverAction.cs
+++ b/Assets/Black Orbit/Scripts/AI/Runtime/Actions/Movement/TakeCoverAction.cs
@@ -26,13 +26,9 @@ namespace Black_Orbit.Scripts.AI.Runtime.Actions.Movement
             _searchRadius = Mathf.Max(3f, searchRadius);
             _minDistanceToTarget = Mathf.Max(1f, minDistanceToTarget);
             _curves = curves ?? throw new ArgumentNullException(nameof(curves));
-        }
-
-        public override System.Collections.Generic.IEnumerable<IConsideration> GetConsiderations()
-        {
-            // Приоритет выше, если есть укрытия поблизости и цель видима (угроза)
-            yield return new CoverAvailable(_curves, _agent, _searchRadius);
-            yield return new Visibility(_curves);
+            AddConsiderations(
+                new CoverAvailable(_curves, _agent, _searchRadius),
+                new Visibility(_curves));
         }
 
         public override bool CanStart(Blackboard.Blackboard bb) => _motor != null;

--- a/Assets/Black Orbit/Scripts/AI/Runtime/Actions/Tactics/RetreatDecisionAction.cs
+++ b/Assets/Black Orbit/Scripts/AI/Runtime/Actions/Tactics/RetreatDecisionAction.cs
@@ -27,12 +27,7 @@ namespace Black_Orbit.Scripts.AI.Runtime.Actions.Tactics
             _curves = curves ?? throw new ArgumentNullException(nameof(curves));
             _criticalHealth = Mathf.Clamp01(criticalHealth);
             _maxHealth = Mathf.Clamp01(maxHealth);
-        }
-
-        public override IEnumerable<IConsideration> GetConsiderations()
-        {
-            // Основной драйвер — LowHealth
-            yield return new LowHealth(_curves, _criticalHealth, _maxHealth);
+            AddConsideration(new LowHealth(_curves, _criticalHealth, _maxHealth));
         }
 
         protected override void OnStart(Blackboard.Blackboard bb)


### PR DESCRIPTION
## Summary
- cache AI action considerations in the base AIAction and reuse the evaluation buffer to avoid per-tick allocations
- update combat, movement, and tactics actions to register their considerations once during construction

## Testing
- not run (Unity editor profiling required)


------
https://chatgpt.com/codex/tasks/task_e_68f16b73fd64832aa2bf0fcc54a23b36