### PR TITLE
Add AI weapon handler and improve AI decision logging

### DIFF
--- a/Assembly-CSharp.csproj
+++ b/Assembly-CSharp.csproj
@@ -110,6 +110,7 @@
     <Compile Include="Assets\Black Orbit\Scripts\WeaponSystem\Runtime\BulletPoolManager.cs" />
     <Compile Include="Assets\SCI_FI_MODULAR\Standard Assets\Utility\AlphaButtonClickMask.cs" />
     <Compile Include="Assets\SCI_FI_MODULAR\Standard Assets\Utility\LerpControlledBob.cs" />
+    <Compile Include="Assets\Black Orbit\Scripts\WeaponSystem\Runtime\AIWeaponHandler.cs" />
     <Compile Include="Assets\Black Orbit\Scripts\WeaponSystem\Runtime\StandardWeapon.cs" />
     <Compile Include="Assets\Black Orbit\Scripts\FPS\CharacterAnimator.cs" />
     <Compile Include="Assets\Black Orbit\Scripts\WeaponSystem\ScriptableObjects\BulletScriptableObject.cs" />

--- a/Assets/Black Orbit/Scripts/AI/Runtime/Combat/AICombat.cs
+++ b/Assets/Black Orbit/Scripts/AI/Runtime/Combat/AICombat.cs
@@ -14,9 +14,18 @@ namespace Black_Orbit.Scripts.AI.Runtime.Combat
         private void Awake()
         {
             if (weaponBehaviour != null)
-                _weapon = weaponBehaviour as IWeapon;
+                AssignWeapon(weaponBehaviour as IWeapon);
             if (_weapon == null)
-                _weapon = GetComponentInChildren<IWeapon>();
+                AssignWeapon(GetComponentInChildren<IWeapon>());
+        }
+
+        public void AssignWeapon(IWeapon weapon)
+        {
+            _weapon = weapon;
+            if (weapon is MonoBehaviour behaviour)
+            {
+                weaponBehaviour = behaviour;
+            }
         }
     }
 }

--- a/Assets/Black Orbit/Scripts/AI/Runtime/Controller/AIController.cs
+++ b/Assets/Black Orbit/Scripts/AI/Runtime/Controller/AIController.cs
@@ -160,10 +160,22 @@ namespace Black_Orbit.Scripts.AI.Runtime.Controller
                 var domain = kv.Value;
                 var active = domain.GetActive();
                 if (active == null) continue;
+                float activeScore = 0f;
+                if (LastScores.TryGetValue(domain.Id, out var scores))
+                {
+                    for (int i = 0; i < scores.Count; i++)
+                    {
+                        if (scores[i].name == active.Name)
+                        {
+                            activeScore = scores[i].score;
+                            break;
+                        }
+                    }
+                }
                 frame.winners[domain.Id] = new ActionScore
                 {
                     name = active.Name,
-                    score = 0f, // детальный скор активного можно найти в LastScores
+                    score = activeScore,
                     domain = domain.Id,
                     exec = active.Execution
                 };

--- a/Assets/Black Orbit/Scripts/WeaponSystem/Base/BaseWeapon.cs
+++ b/Assets/Black Orbit/Scripts/WeaponSystem/Base/BaseWeapon.cs
@@ -1,4 +1,5 @@
-﻿using Black_Orbit.Scripts.WeaponSystem.Runtime;
+using System;
+using Black_Orbit.Scripts.WeaponSystem.Runtime;
 using Black_Orbit.Scripts.WeaponSystem.ScriptableObjects;
 
 namespace Black_Orbit.Scripts.WeaponSystem.Base
@@ -6,23 +7,28 @@ namespace Black_Orbit.Scripts.WeaponSystem.Base
     using UnityEngine;
     using System.Collections;
     using static UnityEngine.Quaternion;
-    
+
     public abstract class BaseWeapon : MonoBehaviour, IWeapon
     {
         protected WeaponScriptableObject data;
         protected float lastFireTime;
         protected int currentAmmo;
         protected bool isReloading;
-        
+
         private Transform muzzle;
-        
+
         public bool IsReloading => isReloading;
-        
+        public int CurrentAmmo => currentAmmo;
+        public int MagazineSize => data != null ? data.magazineSize : 0;
+
+        public event Action<int, int> AmmoChanged;
+
         public virtual void Initialize(WeaponScriptableObject weaponData, Transform muzzlePoint)
         {
             data = weaponData;
             muzzle = muzzlePoint;
             currentAmmo = data.magazineSize > 0 ? data.magazineSize : int.MaxValue;
+            NotifyAmmoChanged();
         }
 
         public abstract void TryFire();
@@ -40,6 +46,7 @@ namespace Black_Orbit.Scripts.WeaponSystem.Base
             yield return new WaitForSeconds(data.reloadTime);
             currentAmmo = data.magazineSize;
             isReloading = false;
+            NotifyAmmoChanged();
         }
 
         protected bool CanFire()
@@ -50,8 +57,9 @@ namespace Black_Orbit.Scripts.WeaponSystem.Base
         protected void ConsumeAmmo()
         {
             if (data.magazineSize > 0) currentAmmo--;
+            NotifyAmmoChanged();
         }
-        
+
         protected void FireBullet(float multiplier)
         {
             var bullet = BulletPoolManager.Instance.GetBullet(data.bulletType, data.magazineSize > 0 ? data.magazineSize : 10);
@@ -64,6 +72,11 @@ namespace Black_Orbit.Scripts.WeaponSystem.Base
             ) * muzzle.forward;
 
             bullet.Launch(transform.TransformPoint(muzzle.localPosition), direction, multiplier);
+        }
+
+        protected void NotifyAmmoChanged()
+        {
+            AmmoChanged?.Invoke(currentAmmo, MagazineSize);
         }
     }
 }

--- a/Assets/Black Orbit/Scripts/WeaponSystem/Runtime/AIWeaponHandler.cs
+++ b/Assets/Black Orbit/Scripts/WeaponSystem/Runtime/AIWeaponHandler.cs
@@ -1,0 +1,139 @@
+using UnityEngine;
+using Black_Orbit.Scripts.AI.Runtime.Blackboard;
+using Black_Orbit.Scripts.AI.Runtime.Controller;
+using Black_Orbit.Scripts.AI.Runtime.Combat;
+using Black_Orbit.Scripts.WeaponSystem.Base;
+using Black_Orbit.Scripts.WeaponSystem.ScriptableObjects;
+
+namespace Black_Orbit.Scripts.WeaponSystem.Runtime
+{
+    [DisallowMultipleComponent]
+    [RequireComponent(typeof(AIController))]
+    [RequireComponent(typeof(AICombat))]
+    public class AIWeaponHandler : MonoBehaviour
+    {
+        [Header("Weapon Setup")]
+        [SerializeField] private WeaponScriptableObject weaponData;
+        [SerializeField] private Transform weaponParent;
+        [SerializeField] private Transform rightHand;
+        [SerializeField] private Transform leftHand;
+        [SerializeField] private bool alignHandsOnStart = true;
+
+        private AIController _controller;
+        private AICombat _combat;
+        private GameObject _weaponInstance;
+        private WeaponHandler _weaponHandler;
+        private BaseWeapon _baseWeapon;
+
+        private void Awake()
+        {
+            _controller = GetComponent<AIController>();
+            _combat = GetComponent<AICombat>();
+        }
+
+        private void Start()
+        {
+            if (weaponData == null)
+            {
+#if UNITY_EDITOR
+                Debug.LogWarning("[AIWeaponHandler] Weapon data is not assigned.");
+#endif
+                UpdateBlackboardAmmo(0, 0);
+                return;
+            }
+
+            SpawnWeapon();
+        }
+
+        private void OnDestroy()
+        {
+            if (_baseWeapon != null)
+            {
+                _baseWeapon.AmmoChanged -= OnAmmoChanged;
+            }
+        }
+
+        private void SpawnWeapon()
+        {
+            if (weaponData.weaponPrefab == null)
+            {
+#if UNITY_EDITOR
+                Debug.LogError("[AIWeaponHandler] Weapon prefab is missing in weapon data.");
+#endif
+                UpdateBlackboardAmmo(0, 0);
+                return;
+            }
+
+            var parent = weaponParent != null ? weaponParent : transform;
+            _weaponInstance = Instantiate(weaponData.weaponPrefab, parent);
+
+            _weaponHandler = _weaponInstance.GetComponent<WeaponHandler>();
+            if (_weaponHandler == null)
+            {
+#if UNITY_EDITOR
+                Debug.LogError("[AIWeaponHandler] Weapon prefab must contain a WeaponHandler component.");
+#endif
+                UpdateBlackboardAmmo(0, 0);
+                return;
+            }
+
+            if (alignHandsOnStart)
+            {
+                PositionHands();
+            }
+
+            var muzzle = _weaponHandler.MuzzleHolder;
+            if (muzzle == null)
+            {
+#if UNITY_EDITOR
+                Debug.LogError("[AIWeaponHandler] Weapon prefab requires a muzzle holder.");
+#endif
+                UpdateBlackboardAmmo(0, 0);
+                return;
+            }
+
+            var weapon = _weaponInstance.GetComponent<BaseWeapon>();
+            if (weapon == null)
+            {
+                weapon = _weaponInstance.AddComponent<StandardWeapon>();
+            }
+
+            weapon.Initialize(weaponData, muzzle);
+            _combat.AssignWeapon(weapon);
+
+            _baseWeapon = weapon;
+            _baseWeapon.AmmoChanged += OnAmmoChanged;
+            OnAmmoChanged(_baseWeapon.CurrentAmmo, _baseWeapon.MagazineSize);
+        }
+
+        private void PositionHands()
+        {
+            if (_weaponHandler == null) return;
+
+            if (rightHand != null && _weaponHandler.RightHandHolder != null)
+            {
+                rightHand.position = _weaponHandler.RightHandHolder.position;
+                rightHand.rotation = _weaponHandler.RightHandHolder.rotation;
+            }
+
+            if (leftHand != null && _weaponHandler.LeftHandHolder != null)
+            {
+                leftHand.position = _weaponHandler.LeftHandHolder.position;
+                leftHand.rotation = _weaponHandler.LeftHandHolder.rotation;
+            }
+        }
+
+        private void OnAmmoChanged(int current, int magazine)
+        {
+            UpdateBlackboardAmmo(current, magazine);
+        }
+
+        private void UpdateBlackboardAmmo(int current, int magazine)
+        {
+            if (_controller?.Blackboard == null) return;
+
+            int ammoValue = magazine > 0 ? Mathf.Clamp(current, 0, magazine) : Mathf.Max(current, 0);
+            _controller.Blackboard.Set(BlackboardKeys.SelfAmmo, ammoValue);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add an AIWeaponHandler component that spawns and wires weapons for AI agents, updates hand poses, and keeps ammo in sync with the blackboard
- expose ammo data and change notifications from BaseWeapon so other systems can react to reloads and shots
- let AICombat accept runtime weapon assignments and surface action scores in AIController's behavior log snapshots for clearer debugging

## Testing
- not run (missing dotnet CLI in container)


------
https://chatgpt.com/codex/tasks/task_e_68f162ca5ea0832aa527ca143ce6ceef